### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/nathan-mittelette/kubernetes-webhooks/security/code-scanning/2](https://github.com/nathan-mittelette/kubernetes-webhooks/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow to function. Based on the provided steps, the workflow primarily interacts with the repository contents and uploads coverage reports to Codecov. Therefore, we will set `contents: read` and add any additional permissions only if necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
